### PR TITLE
Deploy app at ca-30x30.nrp-nautilus.io (rename padus slug)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,7 +1,7 @@
 # LLM config template — NO SECRETS.
 #
 # The upstream LLM proxy key lives only in the nginx config (see
-# `padus-nginx` below), which injects the Authorization header
+# `ca-30x30-nginx` below), which injects the Authorization header
 # server-side via `proxy_set_header`. The browser only sees a relative
 # `/api/llm` endpoint and never holds the key.
 #
@@ -9,7 +9,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: padus-config
+  name: ca-30x30-config
   namespace: biodiversity
 data:
   config.template.json: |
@@ -81,7 +81,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: padus-nginx
+  name: ca-30x30-nginx
   namespace: biodiversity
 data:
   nginx.conf.template: |

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: padus
+  name: ca-30x30
   namespace: biodiversity
   labels:
-    app: padus
+    app: ca-30x30
 spec:
   replicas: 1
   strategy:
@@ -14,11 +14,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      app: padus
+      app: ca-30x30
   template:
     metadata:
       labels:
-        app: padus
+        app: ca-30x30
     spec:
       initContainers:
       - name: git-clone
@@ -30,7 +30,7 @@ spec:
           # Clone YOUR app repo (the GitHub repo you created from the template).
           # Update this URL to point to your own GitHub repo:
           # Update this URL to point to your own GitHub repo:
-          git clone --depth 1 https://github.com/boettiger-lab/geo-agent-template.git /tmp/repo
+          git clone --depth 1 https://github.com/boettiger-lab/ca-30x30.git /tmp/repo
           cp /tmp/repo/index.html /usr/share/nginx/html/
           cp /tmp/repo/layers-input.json /usr/share/nginx/html/
           cp /tmp/repo/system-prompt.md /usr/share/nginx/html/
@@ -103,9 +103,9 @@ spec:
         emptyDir: {}
       - name: config-template
         configMap:
-          name: padus-config
+          name: ca-30x30-config
       - name: nginx-template
         configMap:
-          name: padus-nginx
+          name: ca-30x30-nginx
       - name: nginx-conf-d
         emptyDir: {}

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: padus-ingress
+  name: ca-30x30-ingress
   namespace: biodiversity
   annotations:
     haproxy-ingress.github.io/cors-enable: "true"
@@ -16,15 +16,15 @@ spec:
   ingressClassName: haproxy
   tls:
     - hosts:
-        - padus.nrp-nautilus.io
+        - ca-30x30.nrp-nautilus.io
   rules:
-    - host: padus.nrp-nautilus.io
+    - host: ca-30x30.nrp-nautilus.io
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: padus
+                name: ca-30x30
                 port:
                   number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: padus
+  name: ca-30x30
   namespace: biodiversity
   labels:
-    app: padus
+    app: ca-30x30
 spec:
   type: ClusterIP
   selector:
-    app: padus
+    app: ca-30x30
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
Names the deployed app **ca-30x30.nrp-nautilus.io**.

## Changes (k8s/ only)
- Rename the slug `padus` → `ca-30x30` across all manifests: Deployment/Service/Ingress `metadata.name`, `app` labels + selectors, ConfigMap names (`ca-30x30-config`, `ca-30x30-nginx`), ingress backend service.
- Ingress host `padus.nrp-nautilus.io` → **`ca-30x30.nrp-nautilus.io`** (TLS host + rule host).
- Fix the init-container clone URL: `geo-agent-template.git` → `ca-30x30.git` so the pod serves *this* repo's `layers-input.json` / `system-prompt.md` / `index.html` (the leftover template URL would have served the wrong content).

## Deploy (after merge)
```bash
kubectl apply -f k8s/
kubectl rollout status deployment/ca-30x30 -n biodiversity
```
Then verify https://ca-30x30.nrp-nautilus.io/ serves and the HAProxy ingress provisions a cert for the new host.